### PR TITLE
Updated dead link in Network Security Config Vulnerability

### DIFF
--- a/locales/ja/113_android_network_security_config/related_to.md
+++ b/locales/ja/113_android_network_security_config/related_to.md
@@ -1,4 +1,4 @@
 
 - Androidドキュメント: https://developer.android.com/training/articles/security-config
 - ネットワークセキュリティ構成のためのAndroidCodelab:
-https://codelabs.developers.google.com/codelabs/android-network-security-config/#3
+https://developer.android.com/codelabs/android-network-security-config#3

--- a/vulnerabilities/113_android_network_security_config/related_to.md
+++ b/vulnerabilities/113_android_network_security_config/related_to.md
@@ -1,4 +1,4 @@
 
 - Android Documentation: https://developer.android.com/training/articles/security-config
 - Android Codelab for Network Security Configuration:
-https://codelabs.developers.google.com/codelabs/android-network-security-config/#3
+https://developer.android.com/codelabs/android-network-security-config#3


### PR DESCRIPTION
The new working link of Android Codelabs for Network Security Config is is https://developer.android.com/codelabs/android-network-security-config#3