### PR TITLE
Added working links for Disabled SSL CA Validation and Certificate Pinning Testcase

### DIFF
--- a/locales/ja/83_android_sslpinning/related_to.md
+++ b/locales/ja/83_android_sslpinning/related_to.md
@@ -1,5 +1,5 @@
 
-*   OWASP [トランスポート層の保護に関するチートシート](/index.php/Transport_Layer_Protection_Cheat_Sheet "Transport Layer Protection Cheat Sheet")
+*   OWASP [トランスポート層の保護に関するチートシート](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html "Transport Layer Protection Cheat Sheet")
 *   IETF [RFC 1421 (PEM エンコーディング)](http://www.ietf.org/rfc/rfc1421.txt)
 *   IETF [RFC 4648 (Base16、Base32、Base64 エンコーディング)](http://www.ietf.org/rfc/rfc4648.txt)
 *   IETF [RFC 5280 (インターネット X.509, PKIX)](http://www.ietf.org/rfc/rfc5280.txt)
@@ -8,5 +8,5 @@
 *   IETF [RFC 2246 (TLS 1.0)](http://www.ietf.org/rfc/rfc2246.txt)
 *   IETF [RFC 4346 (TLS 1.1)](http://www.ietf.org/rfc/rfc4346.txt)
 *   IETF [RFC 5246 (TLS 1.2)](http://www.ietf.org/rfc/rfc5246.txt)
-*   RSA Laboratories [PKCS#1, RSA 暗号標準](http://www.rsa.com/rsalabs/node.asp?id=2125)
-*   RSA Laboratories [PKCS#6,拡張された証明書構文の標準](http://www.rsa.com/rsalabs/node.asp?id=2128)
+*   RSA Laboratories [PKCS#1, RSA 暗号標準](https://www.eecis.udel.edu/~mills/database/rsa/pkcs-1.asc)
+*   RSA Laboratories [PKCS#6,拡張された証明書構文の標準](https://www.eecis.udel.edu/~mills/database/rsa/pkcs-6.asc)

--- a/vulnerabilities/83_android_sslpinning/related_to.md
+++ b/vulnerabilities/83_android_sslpinning/related_to.md
@@ -1,5 +1,5 @@
 
-*   OWASP [Transport Layer Protection Cheat Sheet](/index.php/Transport_Layer_Protection_Cheat_Sheet "Transport Layer Protection Cheat Sheet")
+*   OWASP [Transport Layer Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html "Transport Layer Protection Cheat Sheet")
 *   IETF [RFC 1421 (PEM Encoding)](http://www.ietf.org/rfc/rfc1421.txt)
 *   IETF [RFC 4648 (Base16, Base32, and Base64 Encodings)](http://www.ietf.org/rfc/rfc4648.txt)
 *   IETF [RFC 5280 (Internet X.509, PKIX)](http://www.ietf.org/rfc/rfc5280.txt)
@@ -8,5 +8,5 @@
 *   IETF [RFC 2246 (TLS 1.0)](http://www.ietf.org/rfc/rfc2246.txt)
 *   IETF [RFC 4346 (TLS 1.1)](http://www.ietf.org/rfc/rfc4346.txt)
 *   IETF [RFC 5246 (TLS 1.2)](http://www.ietf.org/rfc/rfc5246.txt)
-*   RSA Laboratories [PKCS#1, RSA Encryption Standard](http://www.rsa.com/rsalabs/node.asp?id=2125)
-*   RSA Laboratories [PKCS#6, Extended-Certificate Syntax Standard](http://www.rsa.com/rsalabs/node.asp?id=2128)
+*   RSA Laboratories [PKCS#1, RSA Encryption Standard](https://www.eecis.udel.edu/~mills/database/rsa/pkcs-1.asc)
+*   RSA Laboratories [PKCS#6, Extended-Certificate Syntax Standard](https://www.eecis.udel.edu/~mills/database/rsa/pkcs-6.asc)


### PR DESCRIPTION
CJB Ticket for more context : https://appknox.atlassian.net/browse/CJB-220
Comment displaying reasons: https://appknox.atlassian.net/browse/CJB-220?focusedCommentId=11594
Full test case: https://github.com/appknox/vulnerabilities/tree/master/vulnerabilities/83_android_sslpinning